### PR TITLE
feat: Add Dockerfile for SvelteKit application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Node modules
+node_modules
+
+# Git files
+.git
+.gitignore
+
+# VSCode specific files
+.vscode
+
+# Husky files (if not needed in image)
+.husky
+
+# Build output directories (will confirm actual directory later)
+build
+dist
+
+# OS-specific files
+.DS_Store
+
+# Backup files
+*.bak
+
+# Docker files
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application
+FROM oven/bun:1 AS builder
+
+WORKDIR /app
+
+# Copy package.json, bun.lockb, and tsconfig.json
+COPY package.json bun.lockb tsconfig.json ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy the rest of the application source code
+COPY . .
+
+# Build the application (assuming 'bun run build' is the command)
+# We'll confirm the output directory later
+RUN bun run build
+
+# Stage 2: Serve the application with Nginx
+FROM nginx:alpine
+
+# Copy custom Nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built static files from the builder stage
+# Assuming the build output is in /app/build
+COPY --from=builder /app/build /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    # Root directory for static files
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    # Serve static files directly
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Optional: Add headers to prevent caching of index.html
+    # location = /index.html {
+    #     add_header Cache-Control "no-cache, no-store, must-revalidate";
+    #     expires -1;
+    # }
+
+    # Optional: Gzip compression for text-based files
+    # gzip on;
+    # gzip_vary on;
+    # gzip_proxied any;
+    # gzip_comp_level 6;
+    # gzip_types text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+}


### PR DESCRIPTION
This commit introduces a multi-stage Dockerfile to build and serve the SvelteKit application.

- **Builder Stage (`oven/bun:1`):**
  - Installs dependencies using `bun install --frozen-lockfile`.
  - Builds the application using `bun run build`.
  - Assumes the build output is in the `build` directory.

- **Serve Stage (`nginx:alpine`):**
  - Copies the built static assets from the builder stage.
  - Uses a custom `nginx.conf` to serve the application, configured for SPA routing (all requests to non-existent files are redirected to `index.html`).
  - Exposes port 80.

- **`.dockerignore`:** Added to exclude unnecessary files like `node_modules`, `.git`, and build artifacts from the Docker image.

- **`nginx.conf`:** Custom Nginx configuration added to handle SPA routing.